### PR TITLE
PR-mergeFraudsters

### DIFF
--- a/public/js/clientSideReport.js
+++ b/public/js/clientSideReport.js
@@ -3,10 +3,10 @@ function validateNameClient(name) {
     const validFormat = /^[A-Za-z ]+$/;
 
     if (!name || name.trim().length === 0) {
-        return false;
+        return true;
     }
     if (name.trim().length < 2 || name.trim().length > 20) {
-        return false; 
+        return false;
     }
     if (!validFormat.test(name.trim())) {
         return false;
@@ -40,7 +40,7 @@ function validateReport() {
         return field && field.value.trim() !== '';
     });
 
-   
+
     const reportError = document.getElementById('report-error');
     if (!oneFilled) {
         reportError.textContent = 'Report failed: one of the following must be provided: EIN, ITIN, SSN, email or phone.';
@@ -57,7 +57,7 @@ function validateReport() {
 
 document.addEventListener('DOMContentLoaded', function () {
     const form = document.getElementById('reportForm');
-    document.getElementById('rep-phoneNumber').addEventListener('input', function () { 
+    document.getElementById('rep-phoneNumber').addEventListener('input', function () {
         if (!this.value.startsWith('+1')) {
             this.value = '+1' + this.value.replace(/[^\d]/g, '').slice(1);
         }
@@ -77,7 +77,7 @@ document.addEventListener('DOMContentLoaded', function () {
             const nameError = document.getElementById('name-error');
             nameError.textContent = 'Invalid Name';
             nameError.style.display = 'block';
-        }else {
+        } else {
             document.getElementById('name-error').style.display = 'none';
             document.getElementById('name-error').textContent = '';
         }
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
         if (!isValid) {
             event.preventDefault();
-            
+
         } else {
         }
     });

--- a/src/tasks/seed.js
+++ b/src/tasks/seed.js
@@ -1,10 +1,10 @@
-import {dbConnection, closeConnection} from '../config/mongoConnection.js';
-import { createUser,createMaster,getNumOfUsers} from '../db/usersData.js'
-import { createReport,getNumOfReports } from '../db/reportsData.js';
-import { createFeedback,getNumOfFeedback } from '../db/feedbackData.js';
-import { createReview, getNumOfReviews} from '../db/reviewsData.js';
-import { createDetectionRecord,getNumOfDetections } from '../db/detectionsData.js';
-import {getNumOfFraudsters} from '../db/fraudstersData.js'
+import { dbConnection, closeConnection } from '../config/mongoConnection.js';
+import { createUser, createMaster, getNumOfUsers } from '../db/usersData.js'
+import { createReport, getNumOfReports } from '../db/reportsData.js';
+import { createFeedback, getNumOfFeedback } from '../db/feedbackData.js';
+import { createReview, getNumOfReviews } from '../db/reviewsData.js';
+import { createDetectionRecord, getNumOfDetections } from '../db/detectionsData.js';
+import { getNumOfFraudsters } from '../db/fraudstersData.js'
 
 
 const db = await dbConnection();
@@ -15,81 +15,92 @@ console.log(" *********************** 1) creating users ***********************\
 
 createMaster();
 
-let user1 = await createUser("g@gmail.com","Phill","Hawes","ABC","+12128478981","foobar123!", false)
-let user2 = await createUser("h@gmail.com","Jack","Hawes","123 Holdings","+16178478981","foobar123!", false)
-let user3 = await createUser("b@gmail.com","George","Johns","89 Holdings","+12018478981","foobar123!", false)
-let user4 = await createUser("a@gmail.com","Janice","Unice","89 Holdings","+12038478982","foobar123!", false)
-let user5 = await createUser("b@msft.com","Wendy","Johns","Holdings Inc","+14148478981","foobar123!", false)
+let user1 = await createUser("g@gmail.com", "Phill", "Hawes", "ABC", "+12128478981", "foobar123!", false)
+let user2 = await createUser("h@gmail.com", "Jack", "Hawes", "123 Holdings", "+16178478981", "foobar123!", false)
+let user3 = await createUser("b@gmail.com", "George", "Johns", "89 Holdings", "+12018478981", "foobar123!", false)
+let user4 = await createUser("a@gmail.com", "Janice", "Unice", "89 Holdings", "+12038478982", "foobar123!", false)
+let user5 = await createUser("b@msft.com", "Wendy", "Johns", "Holdings Inc", "+14148478981", "foobar123!", false)
 
 let userCnt = await getNumOfUsers();
-console.log('--> created ' +  userCnt +' users\n\n')
+console.log('--> created ' + userCnt + ' users\n\n')
 
 // ************** fraud reports  *********************
 console.log(" *********************** 2) creating reports ***********************\n")
 
 console.log("ignore below harmless errors with 'No valid email addresses retrieved for fraudsterID: $frauderID'. Its because no users have enabled email notifications\n")
 
-let fraud1 = await createReport(user1._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud2 = await createReport(user1._id.toString(),'34-3456789', null, null, 'b123n@gmail.com', '+12123453456', "Bad Sam", 'money_laundering')
-let fraud3 = await createReport(user1._id.toString(),'56-3456789', null, null, 'bad@gmail.com', '+12123453456', "Bad Hank", 'creditcard_fraud')
-let fraud4 = await createReport(user1._id.toString(),null, null, '035-54-9898', 'person1@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud5 = await createReport(user1._id.toString(),'12-3456789', null, '035-54-9898', 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud6 = await createReport(user1._id.toString(),'12-3456789', null, null, 'person2@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud7 = await createReport(user1._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'money_laundering')
-let fraud8 = await createReport(user1._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud9 = await createReport(user1._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'insurance_fraud')
-let fraud10 = await createReport(user1._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'embezzlement')
-let fraud11 = await createReport(user2._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
-let fraud12 = await createReport(user3._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Tim Johnny", 'wire_fraud')
-let fraud13 = await createReport(user4._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Nan Navi", 'wire_fraud')
-let fraud14 = await createReport(user5._id.toString(),'12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Jim", 'mortgage_fraud')
+let fraud1 = await createReport(user1._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud2 = await createReport(user1._id.toString(), '34-3456789', null, null, 'b123n@gmail.com', '+12123453456', "Bad Sam", 'money_laundering')
+let fraud3 = await createReport(user1._id.toString(), '56-3456789', null, null, 'bad@gmail.com', '+12123453456', "Bad Hank", 'creditcard_fraud')
+let fraud4 = await createReport(user1._id.toString(), null, null, '035-54-9898', 'person1@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud5 = await createReport(user1._id.toString(), '12-3456789', null, '035-54-9898', 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud6 = await createReport(user1._id.toString(), '12-3456789', null, null, 'person2@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud7 = await createReport(user1._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'money_laundering')
+let fraud8 = await createReport(user1._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud9 = await createReport(user1._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'insurance_fraud')
+let fraud10 = await createReport(user1._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'embezzlement')
+let fraud11 = await createReport(user2._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Bad Johnny", 'wire_fraud')
+let fraud12 = await createReport(user3._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Tim Johnny", 'wire_fraud')
+let fraud13 = await createReport(user4._id.toString(), '12-3456789', null, null, 'badperson@gmail.com', '+12123453456', "Nan Navi", 'wire_fraud')
+
+
+let fraud14 = await createReport(user5._id.toString(), '11-3456789', null, null, 'badman@gmail.com', '+12123453457', "", 'mortgage_fraud')
+let fraud15 = await createReport(user5._id.toString(), '10-3456789', null, null, 'badwoman@gmail.com', '+12123453458', "Bad", 'mortgage_fraud')
+let fraud16 = await createReport(user5._id.toString(), '19-3456789', null, null, 'badkid@gmail.com', '+12123453459', "Jim", 'mortgage_fraud')
+let fraud17 = await createReport(user5._id.toString(), '13-3456789', null, null, 'badstudent@gmail.com', '+12123453460', "Anna", 'mortgage_fraud')
+let fraud18 = await createReport(user5._id.toString(), '14-3456789', null, null, 'manbad@gmail.com', '+12123453461', "Ann", 'mortgage_fraud')
+let fraud19 = await createReport(user5._id.toString(), '15-3456789', null, null, 'fraud@gmail.com', '+12123453462', "Sue", 'mortgage_fraud')
+let fraud20 = await createReport(user5._id.toString(), '16-3456789', null, null, 'cheat@gmail.com', '+12123453463', "Knot Good", 'mortgage_fraud')
+let fraud21 = await createReport(user5._id.toString(), '17-3456789', null, null, 'robber@gmail.com', '+12123453464', "Nat", 'mortgage_fraud')
+let fraud22 = await createReport(user5._id.toString(), '17-3456789', null, null, 'thiswillhurt@gmail.com', '+12123453465', "Lucky Bob", 'mortgage_fraud')
+
 
 console.log('\n')
 let fraud_cnt = await getNumOfReports();
-console.log('-->  created ' +  fraud_cnt +' reports\n')
+console.log('-->  created ' + fraud_cnt + ' reports\n')
 let fraudsters_cnt = await getNumOfFraudsters();
-console.log('-->  created ' +  fraudsters_cnt +' fraudsters\n\n')
+console.log('-->  created ' + fraudsters_cnt + ' fraudsters\n\n')
 
 // ************** feedback  *********************
 console.log(" *********************** 3) creating feedback ***********************\n")
 
 
-let feedback1 = await createFeedback(user1._id.toString(),'Phil','jim@gmail.com','This site rocks!')
-let feedback2 = await createFeedback(user2._id.toString(),'JAck','jack@gmail.com','This site saved my family from financial ruin')
-let feedback3 = await createFeedback(user3._id.toString(),'George','georg@gmail.com','Love it. Thank you Frap!')
-let feedback4 = await createFeedback(user1._id.toString(),'Phil','jim2@gmail.com','Phil again! I earned a badge! Thanks')
-let feedback5 = await createFeedback(user3._id.toString(),'George','jim@gmail.com','George here.. am going to earn a badge one of these days!')
-let feedback6 = await createFeedback(user3._id.toString(),'George','jim@gmail.com','George here again!!. very close to my first badge now!')
+let feedback1 = await createFeedback(user1._id.toString(), 'Phil', 'jim@gmail.com', 'This site rocks!')
+let feedback2 = await createFeedback(user2._id.toString(), 'JAck', 'jack@gmail.com', 'This site saved my family from financial ruin')
+let feedback3 = await createFeedback(user3._id.toString(), 'George', 'georg@gmail.com', 'Love it. Thank you Frap!')
+let feedback4 = await createFeedback(user1._id.toString(), 'Phil', 'jim2@gmail.com', 'Phil again! I earned a badge! Thanks')
+let feedback5 = await createFeedback(user3._id.toString(), 'George', 'jim@gmail.com', 'George here.. am going to earn a badge one of these days!')
+let feedback6 = await createFeedback(user3._id.toString(), 'George', 'jim@gmail.com', 'George here again!!. very close to my first badge now!')
 
 let feedback_cnt = await getNumOfFeedback();
-console.log('-->  created ' +  feedback_cnt +' feedback\n')
+console.log('-->  created ' + feedback_cnt + ' feedback\n')
 
 // ************** reviews  *********************
 console.log(" *********************** 4) creating reviews ***********************\n")
 
-let review1 = await createReview(user5._id.toString(),'wends', "A+ love it")
-let review2 = await createReview(user4._id.toString(),'JANICE','9 out of 10 from JANICE!')
-let review3 = await createReview(user3._id.toString(),'George V','Frap rocking it')
-let review4 = await createReview(user3._id.toString(),'JJ','How do I turn on email notifications?')
-let review5 = await createReview(user1._id.toString(),'PH','man this site is good')
+let review1 = await createReview(user5._id.toString(), 'wends', "A+ love it")
+let review2 = await createReview(user4._id.toString(), 'JANICE', '9 out of 10 from JANICE!')
+let review3 = await createReview(user3._id.toString(), 'George V', 'Frap rocking it')
+let review4 = await createReview(user3._id.toString(), 'JJ', 'How do I turn on email notifications?')
+let review5 = await createReview(user1._id.toString(), 'PH', 'man this site is good')
 
 let reviews_cnt = await getNumOfReviews();
-console.log('-->  created ' +  reviews_cnt +' reviews\n')
+console.log('-->  created ' + reviews_cnt + ' reviews\n')
 
 // ************** detections  *********************
 console.log(" *********************** 5) creating detections ***********************\n")
 
 
-let detect1 = await createDetectionRecord(true,75,"Fraud detected")
-let detect2 = await  createDetectionRecord(false,5,"No Fraud detected")
-let detect3 = await  createDetectionRecord(true,99,"Massive Fraud detected")
-let detect4 = await  createDetectionRecord(false,1,"No Fraud detected")
-let detect5 = await  createDetectionRecord(true,71,"Minimal Fraud detected")
-let detect6 = await  createDetectionRecord(false,11,"Passing score")
-let detect7 = await  createDetectionRecord(true,80,"Some Fraud detected")
+let detect1 = await createDetectionRecord(true, 75, "Fraud detected")
+let detect2 = await createDetectionRecord(false, 5, "No Fraud detected")
+let detect3 = await createDetectionRecord(true, 99, "Massive Fraud detected")
+let detect4 = await createDetectionRecord(false, 1, "No Fraud detected")
+let detect5 = await createDetectionRecord(true, 71, "Minimal Fraud detected")
+let detect6 = await createDetectionRecord(false, 11, "Passing score")
+let detect7 = await createDetectionRecord(true, 80, "Some Fraud detected")
 
 let dections_cnt = await getNumOfDetections();
-console.log('-->  created ' +  dections_cnt +' detections\n')
+console.log('-->  created ' + dections_cnt + ' detections\n')
 
 console.log(" *********************** finished. exiting ***********************\n")
 

--- a/src/validations/Validations.js
+++ b/src/validations/Validations.js
@@ -173,17 +173,17 @@ export function validateNameFr(name) {
 }
 
 export function validateCompanyName(companyName) {
-    if (typeof companyName !== 'string') {
-        return 'N/A'; 
-    }
-    companyName = companyName.trim();
-    if (companyName.length === 0) {
-        return 'N/A';
-    }
-    if (companyName.length < 3 || companyName.length > 50) {
-        throw new ValidationError("error: Company name must be between 3 and 50 characters");
-    }
-    return companyName.toUpperCase();
+  if (typeof companyName !== 'string') {
+    return 'N/A';
+  }
+  companyName = companyName.trim();
+  if (companyName.length === 0) {
+    return 'N/A';
+  }
+  if (companyName.length < 3 || companyName.length > 50) {
+    throw new ValidationError("error: Company name must be between 3 and 50 characters");
+  }
+  return companyName.toUpperCase();
 }
 
 export function validateCity(city) {
@@ -327,9 +327,16 @@ export function validateFeedbackText(feedbackText) {
   const maxLength = 250;
   const minLetterPercentage = 0.6;
 
-  if (!feedbackText || feedbackText.trim().length < minLength || feedbackText.trim().length > maxLength) throw new ValidationError ("Feedback length must be between 10 and 250 characters ")
+  if (!feedbackText || feedbackText.trim().length < minLength || feedbackText.trim().length > maxLength) throw new ValidationError("Feedback length must be between 10 and 250 characters ")
   const lettersCount = feedbackText.split('').filter(char => char.match(/[A-Za-z]/)).length;
   const letterPercentage = lettersCount / feedbackText.trim().length;
   if (letterPercentage < minLetterPercentage) throw new ValidationError("Text has to contain a minimum of 60% letters")
   return feedbackText;
+}
+
+export function validateFrIds(frIds) {
+  if (!frIds) throw new ValidationError('frIds is missing');
+  if (!Array.isArray(frIds)) throw new ValidationError('validateFrIds argument must be an array');
+  if (frIds.length === 0) throw new ValidationError('frIds must be a non empty array');
+  return frIds;
 }

--- a/views/report.handlebars
+++ b/views/report.handlebars
@@ -1,23 +1,23 @@
 <section id="reportFraud">
-        <h1>Report Fraud</h1>
-        <br>
-        <span class="report-error" id="report-error"></span>
-        <form id="reportForm">
-            <div class="input-group">
+    <h1>Report Fraud</h1>
+    <br>
+    <span class="report-error" id="report-error"></span>
+    <form id="reportForm">
+        <div class="input-group">
             <p>Please enter any fraud information encountered and click Report Fraud when finished.</p>
-            <div class="input-group required" >
+            <div class="input-group">
                 <br>
-                <label for="rep-name" >Your Name</label>
-                <input type="text" id="rep-name" name="name" placeholder="John Smith" required>
+                <label for="rep-name">Fraudster Name</label>
+                <input type="text" id="rep-name" name="name" placeholder="John Smith">
                 <span class="rep-error" id="name-error"></span>
             </div>
-                <br>
+            <br>
             <div class="input-group">
                 <label for="rep-email">Fraudster Email</label>
-                <input type="email" id="rep-email" name="email"  placeholder="jsmith@gmail.com">
+                <input type="email" id="rep-email" name="email" placeholder="jsmith@gmail.com">
                 <span class="rep-error" id="email-error"></span>
             </div>
-                <br>
+            <br>
             <div class="input-group">
                 <label for="rep-ein">Fraudster EIN</label>
                 <input type="text" id="rep-ein" name="ein" placeholder="12-3456789">
@@ -42,27 +42,27 @@
                 <span class="rep-error" id="phone-error"></span>
             </div>
             <br>
-          </div>
-                <div class = "input-group">
-                <label for="rep-fraudType">Fraud Type:</label>
-                <select name="fraudType" id="rep-fraudType">
-                        <option value="select_fraud_type">Select Fraud Type</option>
-                        <option value="wire_fraud">Wire Fraud</option>
-                        <option value ="money_laundering">Money Laundering</option>
-                        <option value ="creditcard_fraud">Credit Card Fraud</option>
-                        <option value="check_fraud">Check Fraud</option>
-                        <option value ="insurance_fraud">Insurance Fraud</option>
-                        <option value ="identify_theft">Identitiy Theft</option>
-                        <option value="phishing">Phishing</option>
-                        <option value ="embezzlement">Embezzlement</option>
-                        <option value ="mortgage_fraud">Mortgage Fraud</option>
-                        <option value ="utility_scam">Utility Scam</option>
-                </select>
-              </div>
-              <br>
-            <button type="submit" class="button">Report Fraud</button>
-        </form>
+        </div>
+        <div class="input-group">
+            <label for="rep-fraudType">Fraud Type:</label>
+            <select name="fraudType" id="rep-fraudType">
+                <option value="select_fraud_type">Select Fraud Type</option>
+                <option value="wire_fraud">Wire Fraud</option>
+                <option value="money_laundering">Money Laundering</option>
+                <option value="creditcard_fraud">Credit Card Fraud</option>
+                <option value="check_fraud">Check Fraud</option>
+                <option value="insurance_fraud">Insurance Fraud</option>
+                <option value="identify_theft">Identitiy Theft</option>
+                <option value="phishing">Phishing</option>
+                <option value="embezzlement">Embezzlement</option>
+                <option value="mortgage_fraud">Mortgage Fraud</option>
+                <option value="utility_scam">Utility Scam</option>
+            </select>
+        </div>
         <br>
-        <p id="error-message"></p>
-    </section>
-    <script src="/js/clientSideReport.js"></script>
+        <button type="submit" class="button">Report Fraud</button>
+    </form>
+    <br>
+    <p id="error-message"></p>
+</section>
+<script src="/js/clientSideReport.js"></script>


### PR DESCRIPTION
I was checking our app today a bit and this is what I have noticed: 

1.	The original thought was that if there is one report with xxx-xx-xxxx ssn number and then other report came with the same ssn, but different other attributes, that those both reports would map to the same fraudster. Which is great. However, if there is a fraudster a. with ssn: 123-45-6789 as its only attribute and fraudster b. with [anna@gmail.com](mailto:anna@gmail.com) as the only attribute, if a new (third) report comes that has both attributes: ssn: 123-45-6789 and email: [anna@gmail.com](mailto:anna@gmail.com), our system would just find the first match and call it a day. However, all three of them should be united into one fraudster. So I changed our system to do that. Now if a report comes, our systems looks if anything needs uniting as a consequence of the new report and merges the fraudsters. 
2.	I also noticed that in Report Fraud page, we had “Your Name” instead of “Fraudster Name”. Fixed that.
3.	Fraudster Name was set as required field, but it should not be. I changed that (plus removed asterisk associated with that from handlebars).
4.	Seed only generates one fraudster, since all fraudsters share the same phone number (along with some other same attributes). I added more reports to generate more fraudsters.

Things I have noticed but haven’t changed yet:

Report page:

1.	“Fraudster Phone Number” should not be a required field.

2.	Should we leave out FraudsterId from Fraudster Look Up Results?